### PR TITLE
Add barebones inference

### DIFF
--- a/Coremelysis/Coremelysis.xcodeproj/project.pbxproj
+++ b/Coremelysis/Coremelysis.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A4BD58C924EC9A9F004F38FB /* MainViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4BD58C824EC9A9F004F38FB /* MainViewModel.swift */; };
+		A4BD58CB24EC9BC7004F38FB /* Sentiment.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4BD58CA24EC9BC7004F38FB /* Sentiment.swift */; };
 		F2625D6A24E5FE5000ABBA88 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2625D6924E5FE5000ABBA88 /* AppDelegate.swift */; };
 		F2625D6C24E5FE5000ABBA88 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2625D6B24E5FE5000ABBA88 /* SceneDelegate.swift */; };
 		F2625D7024E5FE5500ABBA88 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F2625D6F24E5FE5500ABBA88 /* Assets.xcassets */; };
@@ -17,6 +19,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		A4BD58C824EC9A9F004F38FB /* MainViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewModel.swift; sourceTree = "<group>"; };
+		A4BD58CA24EC9BC7004F38FB /* Sentiment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sentiment.swift; sourceTree = "<group>"; };
 		F2625D6624E5FE5000ABBA88 /* Coremelysis.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Coremelysis.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F2625D6924E5FE5000ABBA88 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		F2625D6B24E5FE5000ABBA88 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -61,6 +65,8 @@
 				F2625D6924E5FE5000ABBA88 /* AppDelegate.swift */,
 				F2625D6B24E5FE5000ABBA88 /* SceneDelegate.swift */,
 				F2625D7D24E5FF3200ABBA88 /* MainViewController.swift */,
+				A4BD58C824EC9A9F004F38FB /* MainViewModel.swift */,
+				A4BD58CA24EC9BC7004F38FB /* Sentiment.swift */,
 				F2B96B5D24E755C000AD118B /* AutoLayoutPropertyWrapper.swift */,
 				F2625D6F24E5FE5500ABBA88 /* Assets.xcassets */,
 				F2625D7424E5FE5500ABBA88 /* LaunchScreen.storyboard */,
@@ -149,6 +155,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A4BD58C924EC9A9F004F38FB /* MainViewModel.swift in Sources */,
+				A4BD58CB24EC9BC7004F38FB /* Sentiment.swift in Sources */,
 				F2625D6A24E5FE5000ABBA88 /* AppDelegate.swift in Sources */,
 				F2625D6C24E5FE5000ABBA88 /* SceneDelegate.swift in Sources */,
 				F2625D7E24E5FF3200ABBA88 /* MainViewController.swift in Sources */,
@@ -290,9 +298,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "\"Coremelysis/Preview Content\"";
-				DEVELOPMENT_TEAM = RAZG7U3SR6;
+				DEVELOPMENT_TEAM = L76X5KFZD9;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = Coremelysis/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -310,9 +319,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "\"Coremelysis/Preview Content\"";
-				DEVELOPMENT_TEAM = RAZG7U3SR6;
+				DEVELOPMENT_TEAM = L76X5KFZD9;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = Coremelysis/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Coremelysis/Coremelysis/MainViewController.swift
+++ b/Coremelysis/Coremelysis/MainViewController.swift
@@ -11,11 +11,14 @@ import UIKit
 final class MainViewController: UIViewController {
     @AutoLayout var infoLabel: UILabel
     @AutoLayout var userTextField: UITextField
-    @AutoLayout var analyseButton: UIButton
+    @AutoLayout var analyzeButton: UIButton
     @AutoLayout var resultLabel: UILabel
     @AutoLayout var mainStack: UIStackView
 
-    init() {
+    private let viewModel: MainViewModel
+
+    init(viewModel: MainViewModel) {
+        self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -36,12 +39,13 @@ final class MainViewController: UIViewController {
 
         infoLabel.text = "Information"
         userTextField.placeholder = "Type Here"
-        analyseButton.backgroundColor = .systemBlue
+        analyzeButton.backgroundColor = .systemBlue
+        analyzeButton.addTarget(self, action: #selector(analyze), for: .touchUpInside)
         resultLabel.text = "not infered"
 
         mainStack.addArrangedSubview(infoLabel)
         mainStack.addArrangedSubview(userTextField)
-        mainStack.addArrangedSubview(analyseButton)
+        mainStack.addArrangedSubview(analyzeButton)
         mainStack.addArrangedSubview(resultLabel)
 
         self.view.addSubview(mainStack)
@@ -54,5 +58,9 @@ final class MainViewController: UIViewController {
             mainStack.leadingAnchor.constraint(equalTo: guides.leadingAnchor),
             mainStack.trailingAnchor.constraint(equalTo: guides.trailingAnchor)
         ])
+    }
+
+    @objc private func analyze() {
+        resultLabel.text = viewModel.analyze(userTextField.text ?? "")
     }
 }

--- a/Coremelysis/Coremelysis/MainViewModel.swift
+++ b/Coremelysis/Coremelysis/MainViewModel.swift
@@ -1,0 +1,43 @@
+//
+//  MainViewModel.swift
+//  Coremelysis
+//
+//  Created by Artur Carneiro on 18/08/20.
+//  Copyright © 2020 Rafael Galdino. All rights reserved.
+//
+
+import NaturalLanguage
+
+final class MainViewModel {
+
+    init() {
+
+    }
+
+    func analyze(_ paragraph: String) -> String {
+        let tagger = NLTagger(tagSchemes: [.sentimentScore])
+
+        tagger.string = paragraph
+
+        let analysedString = tagger.tag(at: paragraph.startIndex, unit: .paragraph, scheme: .sentimentScore).0
+
+        if let score = Double(analysedString?.rawValue ?? "0") {
+            switch score {
+            case -1 ... -0.5:
+                return Sentiment.awful.rawValue
+            case ..<0:
+                return Sentiment.bad.rawValue
+            case 0:
+                return Sentiment.neutral.rawValue
+            case ..<0.5:
+                return Sentiment.good.rawValue
+            case ..<1:
+                return Sentiment.great.rawValue
+            default:
+                return Sentiment.notFound.rawValue
+            }
+        }
+
+        return Sentiment.notFound.rawValue
+    }
+}

--- a/Coremelysis/Coremelysis/SceneDelegate.swift
+++ b/Coremelysis/Coremelysis/SceneDelegate.swift
@@ -14,7 +14,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
-        let vc = MainViewController()
+        let vc = MainViewController(viewModel: MainViewModel())
         if let windowScene = scene as? UIWindowScene {
             let window = UIWindow(windowScene: windowScene)
             window.rootViewController = vc

--- a/Coremelysis/Coremelysis/Sentiment.swift
+++ b/Coremelysis/Coremelysis/Sentiment.swift
@@ -1,0 +1,18 @@
+//
+//  Sentiment.swift
+//  Coremelysis
+//
+//  Created by Artur Carneiro on 18/08/20.
+//  Copyright © 2020 Rafael Galdino. All rights reserved.
+//
+
+import Foundation
+
+enum Sentiment: String {
+    case good = "Good"
+    case great = "Great"
+    case bad = "Bad"
+    case awful = "Awful"
+    case neutral = "Neutral"
+    case notFound = "Sentiment not found"
+}


### PR DESCRIPTION
### Motivation:
Implement basic sentiment analysis to the main view.

### Modifications:
Added a viewmodel to the main view with a function to perform a
sentiment analysis on a paragraph. This functions returns a string
with the results of the analysis using a enum called `Sentiment`.

### Result:
Basic sentiment analysis can now be performed on the main view.