### PR TITLE
Add NavBar and TabBar to view hierarchy

### DIFF
--- a/Coremelysis/Coremelysis/MainViewController.swift
+++ b/Coremelysis/Coremelysis/MainViewController.swift
@@ -29,6 +29,7 @@ final class MainViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         self.view.backgroundColor = .systemBackground
+        self.title = "Coremelysis"
         setupLayout()
     }
 

--- a/Coremelysis/Coremelysis/SceneDelegate.swift
+++ b/Coremelysis/Coremelysis/SceneDelegate.swift
@@ -15,9 +15,13 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         let vc = MainViewController(viewModel: MainViewModel())
+        let navViewController = UINavigationController(rootViewController: vc)
+        let tabBarController = UITabBarController(nibName: nil, bundle: nil)
+        tabBarController.viewControllers = [navViewController]
+        navViewController.tabBarItem = UITabBarItem(tabBarSystemItem: .featured, tag: 0)
         if let windowScene = scene as? UIWindowScene {
             let window = UIWindow(windowScene: windowScene)
-            window.rootViewController = vc
+            window.rootViewController = tabBarController
             self.window = window
             window.makeKeyAndVisible()
         }


### PR DESCRIPTION
Motivation:

Our prototype determines that there will be at least 2 more screens to
the project. With that in mind, we need to place all the views inside
both a Navigation Controller and Tab Bar Controller.
We decided to do already in the begining of the app to prevent further
problems.

Modifications:

- Placed `MainViewController` inside a `UINavigationViewController` in
  `SceneDelegate.swift`.
- Placed `UINavigationViewController` inside a `UITabBarController` in
  `SceneDelegate.swift`.
- Changed `MainViewController` title to "Coremelysis".

Result:

Main screen now displays both a navbar with the Coremelysis and a
tabBar.

Notes:

Made by pair programming with @csfar .