### PR TITLE
Add Error Handling and Refactoring

### DIFF
--- a/Coremelysis/Coremelysis.xcodeproj/project.pbxproj
+++ b/Coremelysis/Coremelysis.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 		F2B99ED325091D5A0005D9B4 /* MLManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2B99ED225091D5A0005D9B4 /* MLManager.swift */; };
 		F2B99ED4250920430005D9B4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2625D6924E5FE5000ABBA88 /* AppDelegate.swift */; };
 		F2B99ED5250920470005D9B4 /* Sentiment.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4BD58CA24EC9BC7004F38FB /* Sentiment.swift */; };
+		F2D418342511A51B00474DBC /* MachineLearningError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2D418332511A51B00474DBC /* MachineLearningError.swift */; };
+		F2D418362511BAC000474DBC /* SentimentAnalysisModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2D418352511BAC000474DBC /* SentimentAnalysisModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -44,6 +46,8 @@
 		F28AA119250BBCAE00C928A2 /* SentimentPolarity.mlmodel */ = {isa = PBXFileReference; lastKnownFileType = file.mlmodel; path = SentimentPolarity.mlmodel; sourceTree = "<group>"; };
 		F2B96B5D24E755C000AD118B /* AutoLayoutPropertyWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoLayoutPropertyWrapper.swift; sourceTree = "<group>"; };
 		F2B99ED225091D5A0005D9B4 /* MLManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MLManager.swift; sourceTree = "<group>"; };
+		F2D418332511A51B00474DBC /* MachineLearningError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MachineLearningError.swift; sourceTree = "<group>"; };
+		F2D418352511BAC000474DBC /* SentimentAnalysisModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentimentAnalysisModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -131,6 +135,8 @@
 			isa = PBXGroup;
 			children = (
 				A4BD58CA24EC9BC7004F38FB /* Sentiment.swift */,
+				F2D418332511A51B00474DBC /* MachineLearningError.swift */,
+				F2D418352511BAC000474DBC /* SentimentAnalysisModel.swift */,
 			);
 			path = Enums;
 			sourceTree = "<group>";
@@ -257,10 +263,12 @@
 				F2B99ED5250920470005D9B4 /* Sentiment.swift in Sources */,
 				F2B99ED4250920430005D9B4 /* AppDelegate.swift in Sources */,
 				A4BD58C924EC9A9F004F38FB /* MainViewModel.swift in Sources */,
+				F2D418362511BAC000474DBC /* SentimentAnalysisModel.swift in Sources */,
 				F214C92E24F6AFC600170DA8 /* HistoryModel.swift in Sources */,
 				A486C41324F7F6A50085BC58 /* SettingsViewController.swift in Sources */,
 				F2625D6C24E5FE5000ABBA88 /* SceneDelegate.swift in Sources */,
 				F28AA11A250BBCAE00C928A2 /* SentimentPolarity.mlmodel in Sources */,
+				F2D418342511A51B00474DBC /* MachineLearningError.swift in Sources */,
 				F2B99ED325091D5A0005D9B4 /* MLManager.swift in Sources */,
 				F2625D7E24E5FF3200ABBA88 /* MainViewController.swift in Sources */,
 				F271FC3024F6A89900011DD1 /* HistoryViewController.swift in Sources */,

--- a/Coremelysis/Coremelysis/Enums/MachineLearningError.swift
+++ b/Coremelysis/Coremelysis/Enums/MachineLearningError.swift
@@ -1,0 +1,38 @@
+//
+//  MLError.swift
+//  Coremelysis
+//
+//  Created by Rafael Galdino on 15/09/20.
+//  Copyright © 2020 Rafael Galdino. All rights reserved.
+//
+
+import Foundation
+
+extension MLManager {
+    /// Coremelysis's Machine Learning Errors
+    enum MachineLearningError: Error {
+        /// Machine Learning Error
+        case failedPrediction
+        /// Machine Learning Error
+        case insufficientData
+        /// Machine Learning Error
+        case modelNotAvaiable
+        /// Machine Learning Error
+        case noModelProvided
+    }
+}
+
+extension MLManager.MachineLearningError: CustomStringConvertible {
+    var description: String {
+        switch self {
+        case .failedPrediction:
+            return "Model was not capable of making a prediction."
+        case .insufficientData:
+            return "The data was not sufficient to perform the analysis."
+        case .modelNotAvaiable:
+            return "The model selected could not be used."
+        case .noModelProvided:
+            return "There was no model provided."
+        }
+    }
+}

--- a/Coremelysis/Coremelysis/Enums/Sentiment.swift
+++ b/Coremelysis/Coremelysis/Enums/Sentiment.swift
@@ -15,4 +15,21 @@ enum Sentiment: String {
     case awful = "Awful"
     case neutral = "Neutral"
     case notFound = "Sentiment not found"
+
+    static func of(_ value: Double) -> Sentiment {
+        switch value {
+        case -1 ... -0.5:
+            return Sentiment.awful
+        case ..<0:
+            return Sentiment.bad
+        case 0:
+            return Sentiment.neutral
+        case ..<0.5:
+            return Sentiment.good
+        case ...1:
+            return Sentiment.great
+        default:
+            return Sentiment.notFound
+        }
+    }
 }

--- a/Coremelysis/Coremelysis/Enums/SentimentAnalysisModel.swift
+++ b/Coremelysis/Coremelysis/Enums/SentimentAnalysisModel.swift
@@ -1,0 +1,24 @@
+//
+//  SentimentAnalysisModel.swift
+//  Coremelysis
+//
+//  Created by Rafael Galdino on 16/09/20.
+//  Copyright © 2020 Rafael Galdino. All rights reserved.
+//
+
+import Foundation
+
+/// Sentiment Analysis Model Identifiers
+enum SentimentAnalysisModel: Hashable{
+    /// Apple's [Natural Language](https://developer.apple.com/documentation/naturallanguage) framework
+    case `default`
+
+    /// Vadym Markov's Sentiment Polarity mlmodel implementation
+    /// 
+    ///[Source on Github](https://github.com/cocoa-ai/SentimentCoreMLDemo/blob/master/SentimentPolarity/Resources/SentimentPolarity.mlmodel)
+    case sentimentPolarity
+
+    /// Custom Models
+    /// - url: Model's location inside the bundle.
+    case customModel(url: String)
+}

--- a/Coremelysis/Coremelysis/MachineLearning/MLManager.swift
+++ b/Coremelysis/Coremelysis/MachineLearning/MLManager.swift
@@ -10,31 +10,61 @@ import Foundation
 import NaturalLanguage
 import CoreML
 
-enum SAModel {
-    case standard
-    case sentimentPolarity
-    case custom(url: String)
-}
-
+/// Machine Learning class abstraction for making inferences.
+///
+/// Should not be subclassed or instantiated.
 final class MLManager {
-    private var model: SAModel
-
-    init(model: SAModel = .standard) {
-        self.model = model
+// MARK: Exposed Methods
+    ///Gives the predicted sentiment value of a given paragraph. Throws errors.
+    ///
+    ///Performs sentiment analysis using Apple's [Natural Language](https://developer.apple.com/documentation/naturallanguage) framework and it's return value ranges from -1 to 1, for negative and positive values, respectively.
+    /// - Parameters:
+    ///     - paragraph: Body of text used in the inference. Should be at least one sentence long.
+    static func analyze(_ paragraph: String) throws -> Double {
+        try inferWithNL(paragraph)
     }
 
-    func analyze(_ paragraph: String) -> Double {
-        switch model {
-        case .standard:
-            return inferWithNL(paragraph)
-        case .sentimentPolarity:
-            return inferWithSP(paragraph)
-        case .custom(url: let url):
-            return 0
+    ///Gives the predicted sentiment value of a given paragraph. Can return nil.
+    ///
+    ///Performs sentiment analysis using Apple's [Natural Language](https://developer.apple.com/documentation/naturallanguage) framework and it's return value ranges from -1 to 1, for negative and positive values, respectively.
+    /// - Parameters:
+    ///     - paragraph: Body of text used in the inference. Should be at least one sentence long.
+    static func analyze(_ paragraph: String) -> Double? {
+        try? inferWithNL(paragraph)
+    }
+
+    ///Gives the predicted sentiment values of a given paragraph.
+    ///
+    ///Performs inferences using multiple models. Prediction values are returned in dictionary form with the models names as the keys.
+    /// - Parameters:
+    ///     - paragraph: Body of text used in the inference. Should be at least one sentence long.
+    ///     - models: Models to be used for inference.
+    static func analyze(_ paragraph: String, with models: [SentimentAnalysisModel]) throws -> [SentimentAnalysisModel: Double] {
+        if models.isEmpty {
+            throw MachineLearningError.noModelProvided
         }
+        var predictions = [SentimentAnalysisModel: Double]()
+        for model in models {
+            switch model {
+            case .default:
+                predictions[.default] = try inferWithSP(paragraph)
+            case .sentimentPolarity:
+                predictions[.sentimentPolarity] = try inferWithSP(paragraph)
+            case .customModel(let url):
+//                TODO: Custom Machine Learning algorithims support
+                predictions[.customModel(url: url)] = 0
+            }
+        }
+        return predictions
     }
 
-    private func inferWithNL(_ data: String) -> Double {
+// MARK: Inference Methods
+    ///Uses Natural Language framework to give the predicted sentiment value of a string.
+    ///
+    ///Performs sentiment analysis using Apple's [Natural Language](https://developer.apple.com/documentation/naturallanguage) framework and it's return value ranges from -1 to 1, for negative and positive values, respectively.
+    /// - Parameters:
+    ///     - data: Body of text used in the inference. Should be at least one sentence long.
+    private static func inferWithNL(_ data: String) throws -> Double {
         let tagger = NLTagger(tagSchemes: [.sentimentScore])
 
         tagger.string = data
@@ -42,34 +72,42 @@ final class MLManager {
         let inferenceValue = tagger.tag(at: data.startIndex, unit: .paragraph, scheme: .sentimentScore).0
 
         guard let inference = Double(inferenceValue?.rawValue ?? "nil") else {
-            // TODO: Error handling
-            return 0
+            throw MachineLearningError.failedPrediction
         }
 
         return inference
     }
 
-    private func inferWithSP(_ data: String) -> Double {
+    ///Uses Sentiment Polarity model to give the predicted sentiment value of a string.
+    ///
+    ///Performs sentiment analysis using [Vadym Markov's Sentiment Polarity](https://github.com/cocoa-ai/SentimentCoreMLDemo/blob/master/SentimentPolarity/Resources/SentimentPolarity.mlmodel) model.
+    /// - Parameters:
+    ///     - data: Body of text used in the inference. Should be at least one sentence long.
+    private static func inferWithSP(_ data: String) throws -> Double {
         let spModel = SentimentPolarity()
         let tokens = extractFeatures(from: data)
 
-        do {
-            let score = try spModel.prediction(input: tokens)
-            switch score.classLabel {
-            case "Pos":
-                return 1.0
-            case "Neg":
-                return -1.0
-            default:
-                return 0
-            }
-        } catch {
-            // TODO: Error handling
-            return 0
+        if tokens.isEmpty {
+            throw MachineLearningError.insufficientData
+        }
+
+        let prediction = try spModel.prediction(input: tokens)
+        guard let score = prediction.classProbability[prediction.classLabel] else {
+            throw MachineLearningError.failedPrediction
+        }
+        if prediction.classLabel == "Pos" {
+            return score
+        } else {
+            return -score
         }
     }
-
-    private func extractFeatures(from data: String) -> [String: Double] {
+// MARK: Auxiliary Methods
+    ///Uses Apple's Natural Language framework to extract tokens from text data.
+    ///
+    ///It ignores punctuation, symbols and words with 3 or less characters.
+    /// - Parameters:
+    ///     - data: Text to be suffer feature extraction.
+    private static func extractFeatures(from data: String) -> [String: Double] {
         var tokens = [String: Double]()
 
         let options: NLTagger.Options = [.omitWhitespace, .omitPunctuation, .omitOther]

--- a/Coremelysis/Coremelysis/MainView/MainViewModel.swift
+++ b/Coremelysis/Coremelysis/MainView/MainViewModel.swift
@@ -15,28 +15,12 @@ protocol MainViewModelDelegate: AnyObject {
 final class MainViewModel {
 
     weak var delegate: MainViewModelDelegate?
-    private let mlManager: MLManager
-
-    init(mlManager: MLManager) {
-        self.mlManager = mlManager
-    }
 
     func analyze(_ paragraph: String) -> String {
-        let score = mlManager.analyze(paragraph)
-
-        switch score {
-        case -1 ... -0.5:
-            return Sentiment.awful.rawValue
-        case ..<0:
-            return Sentiment.bad.rawValue
-        case 0:
-            return Sentiment.neutral.rawValue
-        case ..<0.5:
-            return Sentiment.good.rawValue
-        case ...1:
-            return Sentiment.great.rawValue
-        default:
+        guard let score = MLManager.analyze(paragraph) else {
             return Sentiment.notFound.rawValue
         }
+
+        return Sentiment.of(score).rawValue
     }
 }

--- a/Coremelysis/Coremelysis/SceneDelegate.swift
+++ b/Coremelysis/Coremelysis/SceneDelegate.swift
@@ -15,7 +15,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene,
                willConnectTo session: UISceneSession,
                options connectionOptions: UIScene.ConnectionOptions) {
-        let mainVC = MainViewController(viewModel: MainViewModel(mlManager: MLManager()))
+        let mainVC = MainViewController(viewModel: MainViewModel())
         let mainNavController = UINavigationController(rootViewController: mainVC)
         let settingsVC = SettingsViewController(viewModel: SettingsViewModel())
         let settingsNavController = UINavigationController(rootViewController: settingsVC)


### PR DESCRIPTION
Motivation:

Machine Learning is one of the core concepts of the app and as such
should be well documented and handled, as the entire apps experience
depends on it.
MLManager didn't had any kind of state and it made no sense to see it as
an object.

Modifications:

- MLManager class restructured to use static methods.
- Added Machine Learning Error enum file with descriptions for each of
  the cases.
- Added Sentiment Analysis Model enum file for each of the predicted models
  for the app, including custom models, and moved the sentiment ranges
  to this file.
- Made slight adjustments to MainView ViewModel and SceneDelegate to
  conform to the refactoring.

Result:

Errors in the machine learning section of the app now get propagated to
the class consuming it, with more descriptions detailing the causes of
the error. It's now possible to call upon MLManager analyse method
without the need to instantiate an object.